### PR TITLE
log the internal error by default

### DIFF
--- a/config/dev.exs
+++ b/config/dev.exs
@@ -5,3 +5,6 @@ config :app, port: 8000
 
 # Example of database configuration
 # config :app, db_config: %{name: "dev_db", password: "", port: 10000}
+
+config :plug_cowboy,
+  log_exceptions_with_status_code: [400..599]


### PR DESCRIPTION
This seems to be a sensible configuration for a development environment.
